### PR TITLE
Update bitnami/kubectl version to 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.13
+FROM bitnami/kubectl:1.17
 
 LABEL maintainer "Sinlead <opensource@sinlead.com>"
 


### PR DESCRIPTION
This updates the base image kubectl version to 1.17