### PR TITLE
Upgrade Kubectl Version to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.16
+FROM bitnami/kubectl:1.21
 
 LABEL maintainer "Sinlead <opensource@sinlead.com>"
 


### PR DESCRIPTION
This pull requests updates base image to bitnami kubectl 1.21