### PR TITLE
Update kubectl to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.16
+FROM bitnami/kubectl:1.24
 
 LABEL maintainer "Sinlead <opensource@sinlead.com>"
 


### PR DESCRIPTION
You can use my public image with 1.24

https://hub.docker.com/r/error0x001/drone-kubectl/tags